### PR TITLE
Chat history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .venv
 __pycache__/
+chat_history.db

--- a/scripts/01_langchain_introduction.py
+++ b/scripts/01_langchain_introduction.py
@@ -1,25 +1,6 @@
-import argparse
-import os
 from dotenv import load_dotenv
-from langchain.chat_models import init_chat_model
 
-def get_arguments():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-v', '--vendor', type=str, choices=['openai', 'groq'], default='openai')
-    parser.add_argument('-s', '--stream', action='store_true', default=False)
-    return parser.parse_args()
-
-def get_chat_model(vendor: str):
-    print(f'Selected vendor: {vendor}')
-
-    if not os.environ.get(f'{vendor.upper()}_API_KEY'):
-        raise ValueError(f'API key not defined for the vendor {vendor}.')
-
-    if vendor == 'openai':
-        return init_chat_model('gpt-4o-mini', model_provider=vendor)
-    else:
-        return init_chat_model('llama-3.3-70b-versatile', model_provider=vendor)
-
+from chat_config import get_arguments, get_chat_model
 
 def main():
     load_dotenv()

--- a/scripts/02_langchain_chatbot.py
+++ b/scripts/02_langchain_chatbot.py
@@ -1,26 +1,9 @@
-import argparse
-import os
 from dotenv import load_dotenv
-from langchain.chat_models import init_chat_model
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 
-def get_arguments():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-v', '--vendor', type=str, choices=['openai', 'groq'], default='openai')
-    parser.add_argument('-s', '--stream', action='store_true', default=False)
-    return parser.parse_args()
+from chat_config import get_arguments, get_chat_model
 
-def get_chat_model(vendor: str):
-    print(f'Selected vendor: {vendor}')
-
-    if not os.environ.get(f'{vendor.upper()}_API_KEY'):
-        raise ValueError(f'API key not defined for the vendor {vendor}.')
-
-    if vendor == 'openai':
-        return init_chat_model('gpt-4o-mini', model_provider=vendor)
-    else:
-        return init_chat_model('llama-3.3-70b-versatile', model_provider=vendor)
 
 def chat(model: BaseChatModel, stream: bool):
     chat_history: list[BaseMessage] = [

--- a/scripts/03_langchain_chat_history.py
+++ b/scripts/03_langchain_chat_history.py
@@ -1,0 +1,77 @@
+from dotenv import load_dotenv
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+
+from chat_config import get_arguments, get_chat_model
+from db import *
+
+def chat(chat_history: list[BaseMessage], model: BaseChatModel, stream: bool) -> list[tuple[int, str, str]]:
+    position: int = len(chat_history)
+    new_messages: list[tuple[int, str, str]] = []
+
+    user_input = input('  User ("quit" to exit): ')
+    while user_input != 'quit' or user_input == 'exit':
+        print()
+        chat_history.append(HumanMessage(content=user_input))
+        new_messages.append((position, 'user', user_input))
+        position += 1
+
+        ai_response: str = ''
+        if stream:
+            for chunk in model.stream(chat_history):
+                print(chunk.content, end='', flush=True)
+                ai_response += str(chunk.content)
+            print('\n')
+        else:
+            output_message = model.invoke(chat_history)
+            print(f'  AI: {output_message.content}', '\n')
+            ai_response = str(output_message.content)
+
+        chat_history.append(AIMessage(content=ai_response))
+        new_messages.append((position, 'assistant', ai_response))
+        position += 1
+
+        user_input = input('  User ("quit" to exit): ')
+    return new_messages
+
+
+def main():
+    load_dotenv()
+    args = get_arguments()
+    conn = init_db()
+
+    model = get_chat_model(args.vendor)
+    if args.stream:
+        print('Using streaming mode.\n')
+    else:
+        print('Streaming mode disabled.\n')
+
+    chat_id: str = args.chatid
+    chat_history: list[BaseMessage] = []
+    new_messages: list[tuple[int, str, str]] = []
+
+    if args.chatid:
+        chat_history = fetch_history(conn, chat_id)
+
+    if len(chat_history) == 0:
+        chat_id = create_new_chat(conn)
+        print(f'Chat ID: {chat_id}')
+        system_prompt = 'You are a helpful assistant.'
+        chat_history.append(SystemMessage(content=system_prompt))
+        new_messages.append((0, 'system', system_prompt))
+    else:
+        print(f'Chat ID: {chat_id}')
+        print(f'Chat history:')
+        for i in range(len(chat_history)):
+            if i == 0: continue
+            speaker = 'User' if i % 2 == 1 else 'AI'
+            print(f'  {speaker}: {chat_history[i].content}\n')
+
+    new_messages.extend(chat(chat_history, model, args.stream))
+    for message in new_messages:
+        save_message(conn, chat_id, message[0], message[1], message[2])
+
+    conn.close()
+
+
+main()

--- a/scripts/03_langchain_chat_history.py
+++ b/scripts/03_langchain_chat_history.py
@@ -2,19 +2,17 @@ from dotenv import load_dotenv
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 
-from chat_config import get_arguments, get_chat_model
+from chat_config import *
 from db import *
 
-def chat(chat_history: list[BaseMessage], model: BaseChatModel, stream: bool) -> list[tuple[int, str, str]]:
-    position: int = len(chat_history)
-    new_messages: list[tuple[int, str, str]] = []
+def chat(chat_history: list[BaseMessage], model: BaseChatModel, stream: bool) -> list[MessageData]:
+    new_messages: list[MessageData] = []
 
     user_input = input('  User ("quit" to exit): ')
-    while user_input != 'quit' or user_input == 'exit':
+    while user_input != 'quit' and user_input != 'exit':
         print()
         chat_history.append(HumanMessage(content=user_input))
-        new_messages.append((position, 'user', user_input))
-        position += 1
+        new_messages.append(MessageData(datetime.datetime.now(), 'user', user_input))
 
         ai_response: str = ''
         if stream:
@@ -28,8 +26,7 @@ def chat(chat_history: list[BaseMessage], model: BaseChatModel, stream: bool) ->
             ai_response = str(output_message.content)
 
         chat_history.append(AIMessage(content=ai_response))
-        new_messages.append((position, 'assistant', ai_response))
-        position += 1
+        new_messages.append(MessageData(datetime.datetime.now(), 'assistant', ai_response))
 
         user_input = input('  User ("quit" to exit): ')
     return new_messages
@@ -48,7 +45,7 @@ def main():
 
     chat_id: str = args.chatid
     chat_history: list[BaseMessage] = []
-    new_messages: list[tuple[int, str, str]] = []
+    new_messages: list[MessageData] = []
 
     if args.chatid:
         chat_history = fetch_history(conn, chat_id)
@@ -58,7 +55,7 @@ def main():
         print(f'Chat ID: {chat_id}')
         system_prompt = 'You are a helpful assistant.'
         chat_history.append(SystemMessage(content=system_prompt))
-        new_messages.append((0, 'system', system_prompt))
+        new_messages.append(MessageData(datetime.datetime.now(), 'system', system_prompt))
     else:
         print(f'Chat ID: {chat_id}')
         print(f'Chat history:')

--- a/scripts/03_langchain_runnable_history.py
+++ b/scripts/03_langchain_runnable_history.py
@@ -1,0 +1,94 @@
+from dotenv import load_dotenv
+from langchain_core.chat_history import BaseChatMessageHistory
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.runnables import Runnable, RunnableWithMessageHistory
+
+from chat_config import get_arguments, get_chat_model
+from db import *
+
+def get_role(message: BaseMessage) -> str:
+    if isinstance(message, SystemMessage):
+        return 'system'
+    elif isinstance(message, HumanMessage):
+        return 'user'
+    elif isinstance(message, AIMessage):
+        return 'assistant'
+    else:
+        raise ValueError(f'Unsupported message type: {type(message)}')
+
+
+class ChatHistory(BaseChatMessageHistory):
+    def __init__(self, chat_id: str, conn: sqlite3.Connection):
+        self.chat_id: str = chat_id
+        self.conn: sqlite3.Connection = conn
+        self.messages: list[BaseMessage] = fetch_history(self.conn, self.chat_id)
+        self.new_messages: list[tuple[int, str, str]] = []
+        self.position: int = len(self.messages)
+
+        if self.position == 0:
+            self.chat_id = create_new_chat(conn)
+            print(f'Chat ID: {self.chat_id}\n')
+            self.add_message(SystemMessage(content='You are a helpful assistant.'))
+        else:
+            print(f'Chat ID: {self.chat_id}\n')
+            for i in range(self.position):
+                if i == 0: continue
+                print(f'  {"User" if i % 2 == 1 else "AI"}: {self.messages[i].content}\n')
+
+
+    def add_message(self, message: BaseMessage) -> None:
+        self.messages.append(message)
+        self.new_messages.append((self.position, get_role(message), str(message.content)))
+        self.position += 1
+
+    def save_messages(self) -> None:
+        for m in self.new_messages:
+            save_message(self.conn, self.chat_id, m[0], m[1], m[2])
+
+    def clear(self) -> None:
+        self.messages = []
+        self.new_messages = []
+        self.position = 0
+
+
+def chat(chat_history: ChatHistory, chain: Runnable, stream: bool) -> None:
+    user_input = input('  User ("quit" to exit): ')
+    while user_input != 'quit' or user_input == 'exit':
+        ai_response: str = ''
+        if stream:
+            for chunk in chain.stream(user_input, config={'configurable': {'session_id': chat_history.chat_id}}):
+                print(chunk.content, end='', flush=True)
+                ai_response += str(chunk.content)
+            print('\n')
+        else:
+            output_message = chain.invoke(user_input, config={'configurable': {'session_id': chat_history.chat_id}})
+            print(f'  AI: {output_message.content}', '\n')
+            ai_response = str(output_message.content)
+
+        user_input = input('  User ("quit" to exit): ')
+
+
+def main():
+    load_dotenv()
+    args = get_arguments()
+    conn = init_db()
+
+    model = get_chat_model(args.vendor)
+    if args.stream:
+        print('Using streaming mode.\n')
+    else:
+        print('Streaming mode disabled.\n')
+
+    chain: Runnable = RunnableWithMessageHistory(
+        model,
+        lambda chat_id: chat_history if chat_id == chat_history.chat_id else ChatHistory(chat_id, conn)
+    )
+
+    chat_history = ChatHistory(args.chatid, conn)
+    chat(chat_history, chain, args.stream)
+    chat_history.save_messages()
+
+    conn.close()
+
+
+main()

--- a/scripts/chat_config.py
+++ b/scripts/chat_config.py
@@ -7,6 +7,7 @@ def get_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument('-v', '--vendor', type=str, choices=['openai', 'groq'], default='openai')
     parser.add_argument('-s', '--stream', action='store_true', default=False)
+    parser.add_argument('-c', '--chatid', type=str)
     return parser.parse_args()
 
 def get_chat_model(vendor: str) -> BaseChatModel:

--- a/scripts/chat_config.py
+++ b/scripts/chat_config.py
@@ -1,0 +1,21 @@
+import argparse
+import os
+from langchain.chat_models import init_chat_model
+from langchain_core.language_models import BaseChatModel
+
+def get_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v', '--vendor', type=str, choices=['openai', 'groq'], default='openai')
+    parser.add_argument('-s', '--stream', action='store_true', default=False)
+    return parser.parse_args()
+
+def get_chat_model(vendor: str) -> BaseChatModel:
+    print(f'Selected vendor: {vendor}')
+
+    if not os.environ.get(f'{vendor.upper()}_API_KEY'):
+        raise ValueError(f'API key not defined for the vendor {vendor}.')
+
+    if vendor == 'openai':
+        return init_chat_model('gpt-4o-mini', model_provider=vendor)
+    else:
+        return init_chat_model('llama-3.3-70b-versatile', model_provider=vendor)

--- a/scripts/chat_config.py
+++ b/scripts/chat_config.py
@@ -1,7 +1,14 @@
 import argparse
 import os
+from datetime import datetime
+from typing import NamedTuple
 from langchain.chat_models import init_chat_model
 from langchain_core.language_models import BaseChatModel
+
+class MessageData(NamedTuple):
+    time: datetime
+    role: str
+    content: str
 
 def get_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser()

--- a/scripts/db.py
+++ b/scripts/db.py
@@ -1,0 +1,77 @@
+import sqlite3
+import uuid
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+
+def init_db() -> sqlite3.Connection:
+    conn = sqlite3.connect('chat_history.db')
+    conn.cursor().execute(
+        """
+            CREATE TABLE IF NOT EXISTS chats (
+                chat_id TEXT PRIMARY KEY
+            );
+        """
+    )
+    conn.cursor().execute(
+        """
+            CREATE TABLE IF NOT EXISTS messages (
+                message_id TEXT PRIMARY KEY,
+                chat_id TEXT,
+                position INT,
+                role TEXT,
+                content TEXT,
+                FOREIGN KEY(chat_id) REFERENCES chats(chat_id)
+            );
+        """
+    )
+    conn.commit()
+    return conn
+
+def create_new_chat(conn: sqlite3.Connection) -> str:
+    chat_id = str(uuid.uuid4())
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+            INSERT INTO chats
+            (chat_id) VALUES (?);
+        """,
+        [chat_id]
+    )
+    conn.commit()
+    return chat_id
+
+def fetch_history(conn: sqlite3.Connection, chat_id: str) -> list[BaseMessage]:
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+            SELECT role, content FROM messages
+            WHERE chat_id = ?
+            ORDER BY position ASC;
+        """,
+        [chat_id]
+    )
+    rows: list[tuple[str, str]] = cursor.fetchall()
+
+    chat: list[BaseMessage] = []
+    for role, content in rows:
+        if role == 'system':
+            chat.append(SystemMessage(content))
+        elif role == 'user':
+            chat.append(HumanMessage(content))
+        elif role == 'assistant':
+            chat.append(AIMessage(content))
+        else:
+            raise ValueError(f'Unknown role in DB: {role}')
+    return chat
+
+def save_message(conn: sqlite3.Connection, chat_id: str, position: int, role: str, content: str) -> None:
+    cursor = conn.cursor()
+    message_id = str(uuid.uuid4())
+
+    cursor.execute(
+        """
+            INSERT INTO messages (message_id, chat_id, position, role, content)
+            VALUES (?, ?, ?, ?, ?);
+        """,
+        (message_id, chat_id, position, role, content)
+    )
+    conn.commit()

--- a/scripts/db.py
+++ b/scripts/db.py
@@ -1,3 +1,4 @@
+import datetime
 import sqlite3
 import uuid
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
@@ -16,7 +17,7 @@ def init_db() -> sqlite3.Connection:
             CREATE TABLE IF NOT EXISTS messages (
                 message_id TEXT PRIMARY KEY,
                 chat_id TEXT,
-                position INT,
+                time TIMESTAMP,
                 role TEXT,
                 content TEXT,
                 FOREIGN KEY(chat_id) REFERENCES chats(chat_id)
@@ -45,7 +46,7 @@ def fetch_history(conn: sqlite3.Connection, chat_id: str) -> list[BaseMessage]:
         """
             SELECT role, content FROM messages
             WHERE chat_id = ?
-            ORDER BY position ASC;
+            ORDER BY time ASC;
         """,
         [chat_id]
     )
@@ -63,15 +64,15 @@ def fetch_history(conn: sqlite3.Connection, chat_id: str) -> list[BaseMessage]:
             raise ValueError(f'Unknown role in DB: {role}')
     return chat
 
-def save_message(conn: sqlite3.Connection, chat_id: str, position: int, role: str, content: str) -> None:
+def save_message(conn: sqlite3.Connection, chat_id: str, time: datetime.datetime, role: str, content: str) -> None:
     cursor = conn.cursor()
     message_id = str(uuid.uuid4())
 
     cursor.execute(
         """
-            INSERT INTO messages (message_id, chat_id, position, role, content)
+            INSERT INTO messages (message_id, chat_id, time, role, content)
             VALUES (?, ?, ?, ?, ?);
         """,
-        (message_id, chat_id, position, role, content)
+        (message_id, chat_id, time, role, content)
     )
     conn.commit()


### PR DESCRIPTION
Helper functions have been moved to a separate Python file.

A new file (`db.py`) for SQLite functions has been created.

A new Python script has been created for a chatbot with persistent chats, where you can resume conversations using the `--chatid <chat-uuid>` argument.

A separate version of the chatbot with persistent data has been created, using `Runnable` and `RunnableWithMessageHistory` to manage the conversation history.

<img width="1728" alt="chatbot_with_history" src="https://github.com/user-attachments/assets/4111cb6f-4980-4d5f-9a17-c9792c67c883" />